### PR TITLE
Feature/get customer logged in history

### DIFF
--- a/mongoscripts/01-customers.js
+++ b/mongoscripts/01-customers.js
@@ -9,7 +9,7 @@ db.customers.insertMany([
     password: '$2a$12$rCMpOnOuZMulEy.SrzMH7.mx3gzWgwVh96EgIuKuvYXI7A.9SBJJK', //test123
     email: 'johndoe85@gmail.com',
     date_created: new Date('2022-12-01T10:00:00.000Z'), //Stored in ISO format
-    latest_device: 'WINDOWS - CHROME',
+    latest_device: 'WINDOWS - CHROME - 192.168.0.1',
   },
   {
     _id: ObjectId('000000000001000000000002'),
@@ -21,7 +21,7 @@ db.customers.insertMany([
     password: '$2a$12$rCMpOnOuZMulEy.SrzMH7.mx3gzWgwVh96EgIuKuvYXI7A.9SBJJK', //test123
     email: 'janesmith90@gmail.com',
     date_created: new Date('2022-11-15T11:30:00.000Z'),
-    latest_device: 'WINDOWS - CHROME',
+    latest_device: 'WINDOWS - CHROME - 192.168.0.1',
   },
   {
     _id: ObjectId('000000000001000000000003'),
@@ -33,7 +33,7 @@ db.customers.insertMany([
     password: '$2a$12$rCMpOnOuZMulEy.SrzMH7.mx3gzWgwVh96EgIuKuvYXI7A.9SBJJK', //test123
     email: 'michaelj95@gmail.com',
     date_created: new Date('2022-10-20T09:00:00.000Z'),
-    latest_device: 'WINDOWS - CHROME',
+    latest_device: 'WINDOWS - CHROME - 192.168.0.1',
   },
   {
     _id: ObjectId('000000000001000000000004'),
@@ -45,7 +45,7 @@ db.customers.insertMany([
     password: '$2a$12$rCMpOnOuZMulEy.SrzMH7.mx3gzWgwVh96EgIuKuvYXI7A.9SBJJK', //test123
     email: 'emilybrown92@gmail.com',
     date_created: new Date('2022-09-10T14:00:00.000Z'),
-    latest_device: 'WINDOWS - CHROME',
+    latest_device: 'WINDOWS - CHROME - 192.168.0.1',
   },
   {
     _id: ObjectId('000000000001000000000005'),
@@ -57,6 +57,6 @@ db.customers.insertMany([
     password: '$2a$12$rCMpOnOuZMulEy.SrzMH7.mx3gzWgwVh96EgIuKuvYXI7A.9SBJJK', //test123
     email: 'davidw87@gmail.com',
     date_created: new Date('2022-10-20T09:00:00.000Z'),
-    latest_device: 'WINDOWS - CHROME',
+    latest_device: 'WINDOWS - CHROME - 192.168.0.1',
   },
 ]);

--- a/mongoscripts/01-customers.js
+++ b/mongoscripts/01-customers.js
@@ -10,6 +10,7 @@ db.customers.insertMany([
     email: 'johndoe85@gmail.com',
     date_created: new Date('2022-12-01T10:00:00.000Z'), //Stored in ISO format
     latest_device: 'WINDOWS - CHROME - 192.168.0.1',
+    device_history: ['WINDOWS - CHROME - 192.168.0.1'],
   },
   {
     _id: ObjectId('000000000001000000000002'),
@@ -22,6 +23,7 @@ db.customers.insertMany([
     email: 'janesmith90@gmail.com',
     date_created: new Date('2022-11-15T11:30:00.000Z'),
     latest_device: 'WINDOWS - CHROME - 192.168.0.1',
+    device_history: ['WINDOWS - CHROME - 192.168.0.1'],
   },
   {
     _id: ObjectId('000000000001000000000003'),
@@ -33,7 +35,7 @@ db.customers.insertMany([
     password: '$2a$12$rCMpOnOuZMulEy.SrzMH7.mx3gzWgwVh96EgIuKuvYXI7A.9SBJJK', //test123
     email: 'michaelj95@gmail.com',
     date_created: new Date('2022-10-20T09:00:00.000Z'),
-    latest_device: 'WINDOWS - CHROME - 192.168.0.1',
+    device_history: ['WINDOWS - CHROME - 192.168.0.1'],
   },
   {
     _id: ObjectId('000000000001000000000004'),
@@ -45,7 +47,7 @@ db.customers.insertMany([
     password: '$2a$12$rCMpOnOuZMulEy.SrzMH7.mx3gzWgwVh96EgIuKuvYXI7A.9SBJJK', //test123
     email: 'emilybrown92@gmail.com',
     date_created: new Date('2022-09-10T14:00:00.000Z'),
-    latest_device: 'WINDOWS - CHROME - 192.168.0.1',
+    device_history: ['WINDOWS - CHROME - 192.168.0.1'],
   },
   {
     _id: ObjectId('000000000001000000000005'),
@@ -57,6 +59,6 @@ db.customers.insertMany([
     password: '$2a$12$rCMpOnOuZMulEy.SrzMH7.mx3gzWgwVh96EgIuKuvYXI7A.9SBJJK', //test123
     email: 'davidw87@gmail.com',
     date_created: new Date('2022-10-20T09:00:00.000Z'),
-    latest_device: 'WINDOWS - CHROME - 192.168.0.1',
+    device_history: ['WINDOWS - CHROME - 192.168.0.1'],
   },
 ]);

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -28,18 +28,19 @@ const deviceDetector = new DeviceDetector();
 function getDevice(headers: { 'user-agent': string }): string {
   const userAgent = headers['user-agent'];
   const result = deviceDetector.parse(userAgent);
+  let device = '';
   // console.log(JSON.stringify(result));
   if (!result.os) {
-    return (
+    device =
       'POSTMAN - ' +
-      JSON.stringify(result.client.name).toUpperCase().slice(1, -1)
-    );
+      JSON.stringify(result.client.name).toUpperCase().slice(1, -1);
+  } else {
+    device =
+      JSON.stringify(result.os.name).toUpperCase().slice(1, -1) +
+      ' - ' +
+      JSON.stringify(result.client.name).toUpperCase().slice(1, -1);
   }
-  return (
-    JSON.stringify(result.os.name).toUpperCase().slice(1, -1) +
-    ' - ' +
-    JSON.stringify(result.client.name).toUpperCase().slice(1, -1)
-  );
+  return device;
 }
 @Controller('auth')
 export class AuthController {
@@ -131,12 +132,19 @@ export class AuthController {
     const ipAddress =
       req.headers['x-forwarded-for'] || req.connection.remoteAddress;
     let latest_device = getDevice(req.headers);
-    latest_device += ' - ' + ipAddress.slice(7);
+    let date = new Date();
+    date.setUTCHours(date.getUTCHours() + 7);
+    let device_history =
+      latest_device + ' - ' + ipAddress.slice(7) + ' - ' + date;
     console.log(latest_device);
 
     switch (userType) {
       case UserType.CUSTOMER:
-        await this.customerService.updateLatestDevice(user.id, latest_device);
+        await this.customerService.updateLatestDevice(
+          user.id,
+          latest_device,
+          device_history,
+        );
         break;
       case UserType.ADMIN:
         await this.adminService.updateLatestDevice(user.id, latest_device);

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -132,12 +132,22 @@ export class AuthController {
     const ipAddress =
       req.headers['x-forwarded-for'] || req.connection.remoteAddress;
     let latest_device = getDevice(req.headers);
+
     let date = new Date();
     date.setUTCHours(date.getUTCHours() + 7);
+    const day = date.getDate().toString().padStart(2, '0');
+    const month = (date.getMonth() + 1).toString().padStart(2, '0');
+    const year = date.getFullYear();
+    const hours = date.getHours().toString().padStart(2, '0');
+    const minutes = date.getMinutes().toString().padStart(2, '0');
+    const seconds = date.getSeconds().toString().padStart(2, '0');
+
+    const formattedDate = `${day}/${month}/${year} ${hours}:${minutes}:${seconds}`;
+
     let device_history: HistoryDevice = {
       device: latest_device,
       ip: ipAddress.slice(7),
-      date: date,
+      date: formattedDate,
     };
 
     switch (userType) {

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -128,7 +128,10 @@ export class AuthController {
       throw new UnauthorizedException('Invalid email or password');
     }
 
-    const latest_device = getDevice(req.headers);
+    const ipAddress =
+      req.headers['x-forwarded-for'] || req.connection.remoteAddress;
+    let latest_device = getDevice(req.headers);
+    latest_device += ' - ' + ipAddress.slice(7);
     console.log(latest_device);
 
     switch (userType) {
@@ -174,7 +177,7 @@ export class AuthController {
       token,
     );
     console.log(isValidToken);
-    
+
     if (isValidToken) {
       return { message: 'Token is valid' };
     } else {

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -14,7 +14,6 @@ import {
 } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import * as bcrypt from 'bcrypt';
-import { LocalAuthGuard } from './guards/local.auth.guard';
 import { UserType } from './constants';
 import { CustomersService } from 'src/customers/customers.service';
 import { AdminsService } from 'src/admins/admins.service';
@@ -23,7 +22,8 @@ import DeviceDetector = require('device-detector-js');
 import { JwtService } from '@nestjs/jwt';
 import { JwtAuthService } from './jwt.service';
 import { RolesGuard } from './guards/roles.auth.guard';
-import { AuthGuard } from '@nestjs/passport';
+import { HistoryDevice } from 'src/customers/entities/customers.entity';
+
 const deviceDetector = new DeviceDetector();
 function getDevice(headers: { 'user-agent': string }): string {
   const userAgent = headers['user-agent'];
@@ -134,9 +134,11 @@ export class AuthController {
     let latest_device = getDevice(req.headers);
     let date = new Date();
     date.setUTCHours(date.getUTCHours() + 7);
-    let device_history =
-      latest_device + ' - ' + ipAddress.slice(7) + ' - ' + date;
-    console.log(latest_device);
+    let device_history: HistoryDevice = {
+      device: latest_device,
+      ip: ipAddress.slice(7),
+      date: date,
+    };
 
     switch (userType) {
       case UserType.CUSTOMER:

--- a/src/customers/customers.controller.ts
+++ b/src/customers/customers.controller.ts
@@ -56,4 +56,10 @@ export class CustomersController {
       };
     }
   }
+
+  @Get('/:customerId/history')
+  async getHistory(@Param('customerId') customerId: string) {
+    const history = await this.customerService.getHistory(customerId);
+    return history;
+  }
 }

--- a/src/customers/customers.service.ts
+++ b/src/customers/customers.service.ts
@@ -19,17 +19,20 @@ export class CustomersService {
     private readonly emailService: EmailService,
   ) {}
 
-
   async insertNewCustomer(createCustomerDto: CreateCustomerDto) {
     const newCustomer = new this.customerModel(createCustomerDto);
     await newCustomer.save();
     return newCustomer;
   }
-  
 
-  async updateLatestDevice(customerId: string, latest_device: string) {
+  async updateLatestDevice(
+    customerId: string,
+    latest_device: string,
+    device_history: string,
+  ) {
     const customer = await this.customerModel.findById(customerId);
     customer.latest_device = latest_device;
+    customer.device_history.push(device_history);
     await customer.save();
     return customer;
   }
@@ -44,7 +47,7 @@ export class CustomersService {
     return customer;
   }
 
-    async getCustomerByEmail(email: string) {
+  async getCustomerByEmail(email: string) {
     const customer = await this.customerModel.findOne({ email });
     return customer;
   }

--- a/src/customers/customers.service.ts
+++ b/src/customers/customers.service.ts
@@ -73,4 +73,9 @@ export class CustomersService {
     await customer.save();
     return customer;
   }
+
+  async getHistory(customerId: string) {
+    const customer = await this.customerModel.findById(customerId);
+    return customer.device_history;
+  }
 }

--- a/src/customers/customers.service.ts
+++ b/src/customers/customers.service.ts
@@ -74,6 +74,6 @@ export class CustomersService {
 
   async getHistory(customerId: string) {
     const customer = await this.customerModel.findById(customerId);
-    return customer.device_history;
+    return customer.device_history.reverse();
   }
 }

--- a/src/customers/customers.service.ts
+++ b/src/customers/customers.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
-import { Customer } from './entities/customers.entity';
+import { Customer, HistoryDevice } from './entities/customers.entity';
 import { CreateCustomerDto } from './dto/create-customer.dto';
 import * as crypto from 'crypto';
 import { DateTime } from 'luxon';
@@ -28,7 +28,7 @@ export class CustomersService {
   async updateLatestDevice(
     customerId: string,
     latest_device: string,
-    device_history: string,
+    device_history: HistoryDevice,
   ) {
     const customer = await this.customerModel.findById(customerId);
     customer.latest_device = latest_device;
@@ -61,8 +61,6 @@ export class CustomersService {
     birthdate: string,
     email: string,
   ) {
-    console.log(customerId);
-
     const customer = await this.customerModel.findById(customerId);
     customer.firstname = firstname;
     customer.lastname = lastname;

--- a/src/customers/dto/create-customer.dto.ts
+++ b/src/customers/dto/create-customer.dto.ts
@@ -1,20 +1,20 @@
 import { IsEmail, IsNotEmpty } from 'class-validator';
 
 export class CreateCustomerDto {
-    @IsNotEmpty()
-    username: string;
-  
-    @IsNotEmpty()
-    password: string;
-  
-    @IsEmail()
-    email: string;
-  
-    firstname?: string;
-    lastname?: string;
-    sex?: string;
-    birthdate?: string;
-    date_created?: Date;
-    latest_device?: string;
-  }
-  
+  @IsNotEmpty()
+  username: string;
+
+  @IsNotEmpty()
+  password: string;
+
+  @IsEmail()
+  email: string;
+
+  firstname?: string;
+  lastname?: string;
+  sex?: string;
+  birthdate?: string;
+  date_created?: Date;
+  latest_device?: string;
+  device_history?: string[];
+}

--- a/src/customers/entities/customers.entity.ts
+++ b/src/customers/entities/customers.entity.ts
@@ -10,6 +10,7 @@ export interface Customer extends Document {
   email: string;
   latest_device: string;
   date_created: Date;
+  device_history: string[];
 }
 
 export const CustomerSchema = new Schema({
@@ -43,6 +44,11 @@ export const CustomerSchema = new Schema({
   },
   latest_device: {
     type: String,
+  },
+  device_history: {
+    type: Array<string>,
+    required: true,
+    default: [],
   },
 });
 

--- a/src/customers/entities/customers.entity.ts
+++ b/src/customers/entities/customers.entity.ts
@@ -3,7 +3,7 @@ import { Schema, model, Document } from 'mongoose';
 export interface HistoryDevice {
   device: string;
   ip: string;
-  date: Date;
+  date: string;
 }
 
 export interface Customer extends Document {

--- a/src/customers/entities/customers.entity.ts
+++ b/src/customers/entities/customers.entity.ts
@@ -1,5 +1,11 @@
 import { Schema, model, Document } from 'mongoose';
 
+export interface HistoryDevice {
+  device: string;
+  ip: string;
+  date: Date;
+}
+
 export interface Customer extends Document {
   firstname: string;
   sex: string;
@@ -10,7 +16,7 @@ export interface Customer extends Document {
   email: string;
   latest_device: string;
   date_created: Date;
-  device_history: string[];
+  device_history: HistoryDevice[];
 }
 
 export const CustomerSchema = new Schema({
@@ -46,7 +52,7 @@ export const CustomerSchema = new Schema({
     type: String,
   },
   device_history: {
-    type: Array<string>,
+    type: Array<HistoryDevice>,
     required: true,
     default: [],
   },


### PR DESCRIPTION
## As a Customer, I want to track my logged-in history, So that I can identify or clarify each logged-in in my history.

 This pull request adds a new GET API endpoint (localhost:3000/customers/:id/history) to retrieve the device history of a customer, sorted in reverse chronological order (newest to oldest).

### Testing
To test the API:

1. Register a new customer or log in to an existing customer.
2. Copy the customer ID and paste it into the endpoint of the API (localhost:3000/customers/:id/history).
3. Send the request and inspect the response. The API will return the device history of the customer, sorted from newest to oldest, as shown in the attached screenshot.
### Screenshots
![image](https://user-images.githubusercontent.com/88971721/224494329-64f968f8-0e72-45b8-a6ef-f631cef1ea8a.png)
