### PR TITLE
Feature/logged in history for provider

### DIFF
--- a/mongoscripts/02-providers.js
+++ b/mongoscripts/02-providers.js
@@ -11,6 +11,7 @@ db.providers.insertMany([
       ObjectId('000000000004000000000002'),
     ],
     stripe_account_id: 'acct_1Msp19Q6hJlrjKYC',
+    device_history: ['WINDOWS - CHROME - 192.168.0.1'],
   },
   {
     _id: ObjectId('000000000002000000000002'),
@@ -21,6 +22,7 @@ db.providers.insertMany([
     organization_name: 'Provider Co.',
     locations: [ObjectId('000000000004000000000003')],
     stripe_account_id: 'acct_1Msp63Q3c3AKfNRa',
+    device_history: ['WINDOWS - CHROME - 192.168.0.1'],
   },
   {
     _id: ObjectId('000000000002000000000003'),
@@ -31,6 +33,7 @@ db.providers.insertMany([
     organization_name: 'Provider LLC',
     locations: [ObjectId('000000000004000000000004')],
     stripe_account_id: 'acct_1MsoqgPqkVkOUZkn',
+    device_history: ['WINDOWS - CHROME - 192.168.0.1'],
   },
   
 ]);

--- a/src/providers/entities/provider.entity.ts
+++ b/src/providers/entities/provider.entity.ts
@@ -9,6 +9,7 @@ export interface Provider extends Document {
   organization_name: string;
   locations: Array<any>;
   stripe_account_id?: string;
+  device_history: Array<string>;
 }
 
 export const ProviderSchema = new Schema({
@@ -40,6 +41,9 @@ export const ProviderSchema = new Schema({
   },
   stripe_account_id: {
     type: String,
+  },
+  device_history: {
+    type: [String],
   },
 });
 

--- a/src/providers/providers.controller.ts
+++ b/src/providers/providers.controller.ts
@@ -16,6 +16,7 @@ import {
   ApiResponse,
   ApiBody,
   ApiQuery,
+  ApiParam,
 } from '@nestjs/swagger'; // Import Swagger decorators
 @ApiTags('Providers') // Add tags for the API group
 @Controller('providers')
@@ -25,5 +26,14 @@ export class ProvidersController {
   @ApiOperation({ summary: 'Get locations by provider id' })
   async getLocationsByProvideId(@Param('providerId') providerId: string) {
     return this.providersService.getLocationsByProviderId(providerId);
+  }
+
+  @Get('/:providerId/history')
+  @ApiOperation({ summary: 'Get logged-in history of the provider by ID' }) // Add operation summary
+  @ApiParam({ name: 'providerId', description: 'Provider ID' }) // Add parameter description
+  @ApiResponse({ status: 200, description: 'OK' }) // Add response description
+  async getHistory(@Param('providerId') providerId: string): Promise<any> {
+    const history = await this.providersService.getHistory(providerId);
+    return history;
   }
 }

--- a/src/providers/providers.service.ts
+++ b/src/providers/providers.service.ts
@@ -30,6 +30,7 @@ export class ProvidersService {
   async updateLatestDevice(providerId: string, latest_device: string) {
     const provider = await this.providerModel.findById(providerId);
     provider.latest_device = latest_device;
+    provider.device_history.push(latest_device);
     await provider.save();
     return provider;
   }

--- a/src/providers/providers.service.ts
+++ b/src/providers/providers.service.ts
@@ -92,18 +92,20 @@ export class ProvidersService {
     return providers;
   }
   async getProviderByLocationId(locationId: string) {
-
     const providers = await this.providerModel.aggregate([
-      { $match: { 'locations': new ObjectId(locationId) } },
+      { $match: { locations: new ObjectId(locationId) } },
     ]);
     console.log(providers);
-    
+
     if (!providers) {
       throw new Error(`Provider not found for location ID: ${locationId}`);
     }
 
     return await providers[0]; // there should only be one provider per location
-
   }
 
+  async getHistory(customerId: string) {
+    const customer = await this.providerModel.findById(customerId);
+    return customer.device_history.reverse();
+  }
 }


### PR DESCRIPTION
This pull request adds a new GET API endpoint (localhost:3000/providers/:id/history) to retrieve the device history of a provider, sorted in reverse chronological order (newest to oldest).